### PR TITLE
Fix wrong VERSION file name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ __gitsha__ = '{}'
 version_info = ({})
 """
     sha = get_hash()
-    with open('VERSION', 'r') as f:
+    with open('VERSION.txt', 'r') as f:
         SHORT_VERSION = f.read().strip()
     VERSION_INFO = ', '.join([x if x.isdigit() else f'"{x}"' for x in SHORT_VERSION.split('.')])
 


### PR DESCRIPTION
`setup.py` is looking for a file called `VERSION`, but the file is actually called `VERSION.txt`
Fixes https://github.com/LabShuHangGU/MIA-VSR/issues/7